### PR TITLE
Added SQL query to retrieve data from Matches table.

### DIFF
--- a/notebooks/Transform & Load.ipynb
+++ b/notebooks/Transform & Load.ipynb
@@ -1959,6 +1959,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ccaebb2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date_df = spark.sql(\"SELECT * FROM Matches\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f8344f2a-3fea-4c53-8c06-97c08089de36",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
This pull request addresses an issue in the Jupyter notebook where match data was needed for further processing. 
I added the following line to fetch the data using Spark SQL:

`date_df = spark.sql("SELECT * FROM Matches")`

This should resolve the data retrieval issue and allow further analysis.